### PR TITLE
DS-8257: Add async support via optional asyncDelay parameter

### DIFF
--- a/sample-isv-web/src/main/java/com/appdirect/isv/config/SchedulingConfiguration.java
+++ b/sample-isv-web/src/main/java/com/appdirect/isv/config/SchedulingConfiguration.java
@@ -1,0 +1,15 @@
+package com.appdirect.isv.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+@Configuration
+public class SchedulingConfiguration {
+	@Bean
+	public ThreadPoolTaskScheduler threadPoolTaskScheduler() {
+		ThreadPoolTaskScheduler threadPoolTaskScheduler = new ThreadPoolTaskScheduler();
+		threadPoolTaskScheduler.setPoolSize(10);
+		return threadPoolTaskScheduler;
+	}
+}

--- a/sample-isv-web/src/main/java/com/appdirect/isv/web/api/AppDirectIntegrationApi.java
+++ b/sample-isv-web/src/main/java/com/appdirect/isv/web/api/AppDirectIntegrationApi.java
@@ -1,0 +1,8 @@
+package com.appdirect.isv.web.api;
+
+import com.appdirect.isv.integration.remote.vo.APIResult;
+
+@FunctionalInterface
+public interface AppDirectIntegrationApi {
+	void registerResult(String eventToken, APIResult apiResult);
+}

--- a/sample-isv-web/src/main/java/com/appdirect/isv/web/api/AppDirectIntegrationApiFactory.java
+++ b/sample-isv-web/src/main/java/com/appdirect/isv/web/api/AppDirectIntegrationApiFactory.java
@@ -1,0 +1,12 @@
+package com.appdirect.isv.web.api;
+
+import org.springframework.stereotype.Component;
+
+import com.appdirect.isv.model.ApplicationProfile;
+
+@Component
+public class AppDirectIntegrationApiFactory {
+	public AppDirectIntegrationApi get(ApplicationProfile applicationProfile) {
+		return new AppDirectIntegrationApiImpl(applicationProfile);
+	}
+}

--- a/sample-isv-web/src/main/java/com/appdirect/isv/web/api/AppDirectIntegrationApiImpl.java
+++ b/sample-isv-web/src/main/java/com/appdirect/isv/web/api/AppDirectIntegrationApiImpl.java
@@ -1,0 +1,19 @@
+package com.appdirect.isv.web.api;
+
+import org.springframework.web.client.RestTemplate;
+
+import com.appdirect.isv.integration.remote.vo.APIResult;
+import com.appdirect.isv.model.ApplicationProfile;
+
+public class AppDirectIntegrationApiImpl implements AppDirectIntegrationApi {
+	private final RestTemplate restTemplate;
+
+	public AppDirectIntegrationApiImpl(ApplicationProfile applicationProfile) {
+		restTemplate = new RestTemplate(new TwoLeggedOAuthClientHttpRequestFactory(applicationProfile));
+	}
+
+	@Override
+	public void registerResult(String eventUrl, APIResult apiResult) {
+		restTemplate.postForObject(eventUrl + "/result", apiResult, Void.class);
+	}
+}

--- a/sample-isv-web/src/main/java/com/appdirect/isv/web/api/TwoLeggedOAuthClientHttpRequestFactory.java
+++ b/sample-isv-web/src/main/java/com/appdirect/isv/web/api/TwoLeggedOAuthClientHttpRequestFactory.java
@@ -1,0 +1,41 @@
+package com.appdirect.isv.web.api;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+
+import com.appdirect.isv.model.ApplicationProfile;
+
+import oauth.signpost.OAuthConsumer;
+import oauth.signpost.basic.DefaultOAuthConsumer;
+import oauth.signpost.exception.OAuthException;
+
+@Slf4j
+public class TwoLeggedOAuthClientHttpRequestFactory extends SimpleClientHttpRequestFactory {
+	private static final int DEFAULT_CONNECT_TIMEOUT_MILLIS = 10_000;
+	private static final int DEFAULT_READ_TIMEOUT_MILLIS = 30_000;
+
+	private final OAuthConsumer consumer;
+
+	public TwoLeggedOAuthClientHttpRequestFactory(ApplicationProfile applicationProfile) {
+		consumer = new DefaultOAuthConsumer(applicationProfile.getOauthConsumerKey(), applicationProfile.getOauthConsumerSecret());
+		setConnectTimeout(DEFAULT_CONNECT_TIMEOUT_MILLIS);
+		setReadTimeout(DEFAULT_READ_TIMEOUT_MILLIS);
+
+		// Disable output streaming to avoid "org.springframework.web.client.ResourceAccessException: I/O error on POST request for [URL]: cannot retry due to server authentication, in streaming mode; nested exception is java.net.HttpRetryException: cannot retry due to server authentication, in streaming mode"
+		setOutputStreaming(false);
+	}
+
+	@Override
+	protected void prepareConnection(HttpURLConnection connection, String httpMethod) throws IOException {
+		super.prepareConnection(connection, httpMethod);
+		try {
+			consumer.sign(connection);
+		} catch (OAuthException e) {
+			log.error("Error while signing request", e);
+		}
+	}
+}

--- a/sample-isv-web/src/main/java/com/appdirect/isv/web/controller/IntegrationController.java
+++ b/sample-isv-web/src/main/java/com/appdirect/isv/web/controller/IntegrationController.java
@@ -1,11 +1,17 @@
 package com.appdirect.isv.web.controller;
 
+import java.util.Date;
+
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 import lombok.extern.slf4j.Slf4j;
 
+import org.apache.commons.lang.time.DateUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.security.authentication.AuthenticationServiceException;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -16,6 +22,9 @@ import com.appdirect.isv.integration.remote.vo.APIResult;
 import com.appdirect.isv.integration.service.IntegrationService;
 import com.appdirect.isv.model.ApplicationProfile;
 import com.appdirect.isv.security.oauth.ContextualApplicationProfileGetter;
+import com.appdirect.isv.web.api.AppDirectIntegrationApi;
+import com.appdirect.isv.web.api.AppDirectIntegrationApiFactory;
+import com.google.common.base.Preconditions;
 
 @Slf4j
 @RestController
@@ -30,44 +39,101 @@ public class IntegrationController {
 	private ContextualApplicationProfileGetter contextualApplicationProfileGetter;
 	@Autowired
 	private IntegrationService integrationService;
+	@Autowired
+	private ThreadPoolTaskScheduler threadPoolTaskScheduler;
+	@Autowired
+	private AppDirectIntegrationApiFactory appDirectIntegrationApiFactory;
 
 	@RequestMapping("/processEvent")
-	public APIResult processEvent(HttpServletRequest request, @RequestParam(value = "eventUrl", required = false) String eventUrl, @RequestParam(value = "token", required = false) String token) {
-		ApplicationProfile applicationProfile = contextualApplicationProfileGetter.get()
-				.orElseThrow(() -> new AuthenticationServiceException("Cannot find contextual application profile."));
-		APIResult result;
-		try {
-			result = integrationService.processEvent(applicationProfile, eventUrl, token);
-		} catch (RuntimeException e) {
-			result = new APIResult();
-			result.setSuccess(false);
-			result.setErrorCode(ErrorCode.UNKNOWN_ERROR);
-			StringBuilder message = new StringBuilder(e.getMessage() != null ? e.getMessage() : e.toString()).append("\n");
-			int i = 0;
-			for (StackTraceElement element : e.getStackTrace()) {
-				message.append(element.toString()).append("\n");
-				if (i++ > 5) {
-					break;
-				}
-			}
-			result.setMessage(message.toString());
+	public APIResult processEvent(HttpServletRequest request, HttpServletResponse response,
+			@RequestParam(value = "eventUrl", required = false) String eventUrl,
+			@RequestParam(value = "token", required = false) String token,
+			@RequestParam(value = "asyncDelay", required = false) Integer asyncDelayMillis) {
+		ApplicationProfile applicationProfile = contextualApplicationProfileGetter.get().orElseThrow(() -> new AuthenticationServiceException("Contextual application profile not found"));
+		String clientIpAddress = extractIpAddress(request);
+		if (asyncDelayMillis == null) {
+			return processEventNow(applicationProfile, clientIpAddress, eventUrl, token);
 		}
-		result.setMessage(String.format("From IP: %s. %s", extractIpAddress(request), result.getMessage()));
-		log.info("Returning [result={}].", result);
+		response.setStatus(HttpStatus.ACCEPTED.value());
+		return processAndRegisterEventLater(applicationProfile, clientIpAddress, eventUrl, asyncDelayMillis);
+	}
+
+	private APIResult processEventNow(ApplicationProfile applicationProfile, String clientIpAddress, String eventUrl, String token) {
+		APIResult apiResult;
+		try {
+			apiResult = integrationService.processEvent(applicationProfile, eventUrl, token);
+		} catch (RuntimeException e) {
+			log.error("Error processing event with eventUrl={} or token={}", eventUrl, token, e);
+			apiResult = toAPIResult(e);
+		}
+		apiResult.setMessage(String.format("From IP: %s. %s", clientIpAddress, apiResult.getMessage()));
+		log.info("Returning [result={}].", apiResult);
+		return apiResult;
+	}
+
+	private APIResult processAndRegisterEventLater(ApplicationProfile applicationProfile, String clientIpAddress, String eventUrl, int asyncDelayMillis) {
+		try {
+			Preconditions.checkState(eventUrl != null, "eventUrl must be specified if asyncDelay is specified");
+			Date startTime = DateUtils.addMilliseconds(new Date(), asyncDelayMillis);
+			log.info("Event with eventUrl={} will be processed asynchronously in {} milliseconds", eventUrl, asyncDelayMillis);
+			threadPoolTaskScheduler.schedule(() -> processAndRegisterEvent(applicationProfile, clientIpAddress, eventUrl), startTime);
+			return new APIResult(true, String.format("Event will be processed asynchronously in %s milliseconds.", asyncDelayMillis));
+		} catch (RuntimeException e) {
+			return toAPIResult(e);
+		}
+	}
+
+	private void processAndRegisterEvent(ApplicationProfile applicationProfile, String clientIpAddress, String eventUrl) {
+		APIResult apiResult;
+		try {
+			log.info("Processing asynchronous event with eventUrl={}", eventUrl);
+			apiResult = processEventNow(applicationProfile, clientIpAddress, eventUrl, null);
+		} catch (RuntimeException e) {
+			log.error("Error processing asynchronous event; result will not be registered", e);
+			return;
+		}
+
+		try {
+			registerResult(applicationProfile, eventUrl, apiResult);
+		} catch (RuntimeException e) {
+			log.error("Error registering asynchronous event result", e);
+			return;
+		}
+	}
+
+	private void registerResult(ApplicationProfile applicationProfile, String eventUrl, APIResult apiResult) {
+		AppDirectIntegrationApi appDirectIntegrationApi = appDirectIntegrationApiFactory.get(applicationProfile);
+		appDirectIntegrationApi.registerResult(eventUrl, apiResult);
+	}
+
+	private APIResult toAPIResult(RuntimeException e) {
+		APIResult result;
+		result = new APIResult();
+		result.setSuccess(false);
+		result.setErrorCode(ErrorCode.UNKNOWN_ERROR);
+		StringBuilder message = new StringBuilder(e.getMessage() != null ? e.getMessage() : e.toString()).append("\n");
+		int i = 0;
+		for (StackTraceElement element : e.getStackTrace()) {
+			message.append(element.toString()).append("\n");
+			if (i++ > 5) {
+				break;
+			}
+		}
+		result.setMessage(message.toString());
 		return result;
 	}
 
 	private String extractIpAddress(HttpServletRequest request) {
-        String ip = request.getHeader(X_FORWARDED_FOR);
-        if (StringUtils.isBlank(ip) || ip.equalsIgnoreCase(UNKNOWN)) {
-            ip = request.getHeader(HTTP_CLIENT_IP);
-        }
-        if (StringUtils.isBlank(ip) || ip.equalsIgnoreCase(UNKNOWN)) {
-            ip = request.getHeader(HTTP_X_FORWARDED_FOR);
-        }
-        if (StringUtils.isBlank(ip) || ip.equalsIgnoreCase(UNKNOWN)) {
-            ip = request.getRemoteAddr();
-        }
+		String ip = request.getHeader(X_FORWARDED_FOR);
+		if (StringUtils.isBlank(ip) || ip.equalsIgnoreCase(UNKNOWN)) {
+			ip = request.getHeader(HTTP_CLIENT_IP);
+		}
+		if (StringUtils.isBlank(ip) || ip.equalsIgnoreCase(UNKNOWN)) {
+			ip = request.getHeader(HTTP_X_FORWARDED_FOR);
+		}
+		if (StringUtils.isBlank(ip) || ip.equalsIgnoreCase(UNKNOWN)) {
+			ip = request.getRemoteAddr();
+		}
 		return ip;
 	}
 }


### PR DESCRIPTION
Adds support for asynchronous event processing using new URL parameter `asyncDelay`.  For example, requesting:

`http://127.0.0.1:9080/api/integration/appdirect/processEvent?eventUrl={eventUrl}&asyncDelay=5000`

will cause the initial request to return success with message "Event will be processed asynchronously in 5000 milliseconds.".  5 seconds later, the result (the same as if `asyncDelay` was not specified) will be asynchronously posted to {eventUrl}/result.
