### PR TITLE
DS-14011 Fix Interactive flow page redirect + DS-14094 createdOn and lastModified fields added to entities

### DIFF
--- a/sample-isv-model/pom.xml
+++ b/sample-isv-model/pom.xml
@@ -14,5 +14,17 @@
 			<groupId>org.hibernate</groupId>
 			<artifactId>hibernate-core</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.data</groupId>
+			<artifactId>spring-data-commons</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-context</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.data</groupId>
+			<artifactId>spring-data-jpa</artifactId>
+		</dependency>
 	</dependencies>
 </project>

--- a/sample-isv-model/src/main/java/com/appdirect/isv/config/JpaConfiguration.java
+++ b/sample-isv-model/src/main/java/com/appdirect/isv/config/JpaConfiguration.java
@@ -1,0 +1,15 @@
+package com.appdirect.isv.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing(auditorAwareRef = "auditorAware")
+public class JpaConfiguration {
+	@Bean(name = "auditorAware")
+	public AuditorAware<String> auditorAware() {
+		return ()->null;
+	}
+}

--- a/sample-isv-model/src/main/java/com/appdirect/isv/model/Account.java
+++ b/sample-isv-model/src/main/java/com/appdirect/isv/model/Account.java
@@ -24,7 +24,7 @@ import com.google.common.collect.Lists;
 @Getter @Setter @NoArgsConstructor(access = AccessLevel.PACKAGE)
 @Entity
 @Table(name = "isv_accounts")
-public class Account {
+public class Account extends TimestampedObject {
 	@Id
 	@GeneratedValue(strategy = GenerationType.AUTO)
 	@Column(name = "id")

--- a/sample-isv-model/src/main/java/com/appdirect/isv/model/Addon.java
+++ b/sample-isv-model/src/main/java/com/appdirect/isv/model/Addon.java
@@ -16,7 +16,7 @@ import lombok.Setter;
 @Getter @Setter @NoArgsConstructor
 @Entity
 @Table(name = "isv_addons")
-public class Addon {
+public class Addon extends TimestampedObject {
 	@Id
 	@GeneratedValue(strategy = GenerationType.AUTO)
 	@Column(name = "id")

--- a/sample-isv-model/src/main/java/com/appdirect/isv/model/ApplicationProfile.java
+++ b/sample-isv-model/src/main/java/com/appdirect/isv/model/ApplicationProfile.java
@@ -18,7 +18,7 @@ import org.hibernate.annotations.Type;
 @Getter @Setter @NoArgsConstructor
 @Entity
 @Table(name = "isv_application_profiles")
-public class ApplicationProfile implements Serializable {
+public class ApplicationProfile extends TimestampedObject implements Serializable {
 	private static final long serialVersionUID = 8749509893827875016L;
 
 	@Id

--- a/sample-isv-model/src/main/java/com/appdirect/isv/model/TimestampedObject.java
+++ b/sample-isv-model/src/main/java/com/appdirect/isv/model/TimestampedObject.java
@@ -1,0 +1,31 @@
+package com.appdirect.isv.model;
+
+import java.util.Date;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@MappedSuperclass
+@Getter
+@Setter
+@NoArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+public abstract class TimestampedObject {
+
+	@CreatedDate
+	@Column(name = "created_on")
+	private Date createdOn;
+
+	@LastModifiedDate
+	@Column(name = "last_modified_date")
+	private Date lastModified;
+}

--- a/sample-isv-model/src/main/java/com/appdirect/isv/model/User.java
+++ b/sample-isv-model/src/main/java/com/appdirect/isv/model/User.java
@@ -18,7 +18,7 @@ import org.hibernate.annotations.Type;
 @Getter @Setter @NoArgsConstructor
 @Entity
 @Table(name = "isv_users")
-public class User {
+public class User extends TimestampedObject {
 	@Id
 	@GeneratedValue(strategy = GenerationType.AUTO)
 	@Column(name = "id")

--- a/sample-isv-web/src/main/java/com/appdirect/isv/integration/wicket/pages/procurement/CancelAccountPage.html
+++ b/sample-isv-web/src/main/java/com/appdirect/isv/integration/wicket/pages/procurement/CancelAccountPage.html
@@ -27,6 +27,7 @@
 			</div>
 			<div>
 				<button wicket:id="cancelAccount">Delete</button>
+				<button wicket:id="failure">Failure</button>
 			</div>
 		</div>
 	</wicket:extend>

--- a/sample-isv-web/src/main/java/com/appdirect/isv/integration/wicket/pages/procurement/CancelAccountSecureRedirectPage.java
+++ b/sample-isv-web/src/main/java/com/appdirect/isv/integration/wicket/pages/procurement/CancelAccountSecureRedirectPage.java
@@ -1,0 +1,27 @@
+package com.appdirect.isv.integration.wicket.pages.procurement;
+
+import org.apache.wicket.request.mapper.parameter.PageParameters;
+import org.wicketstuff.annotation.mount.MountPath;
+
+import com.appdirect.isv.integration.remote.type.EventType;
+import com.appdirect.isv.integration.remote.vo.EventInfo;
+
+/**
+ * This page is secured and acts as an authorization intermediary for the interactive cancel subscription flow.
+ * The user must first go through this secured page to be authenticated and then will be redirected to the unsecured
+ * CancelAccountPage to finish the cancellation flow.
+ */
+@MountPath("/appdirect/cancel")
+public class CancelAccountSecureRedirectPage extends BaseIntegrationPage {
+
+	public CancelAccountSecureRedirectPage(final PageParameters parameters) {
+		super(parameters);
+
+		EventInfo eventInfo = readEvent(parameters);
+		if (eventInfo == null || eventInfo.getType() != EventType.SUBSCRIPTION_CANCEL) {
+			throw new IllegalStateException("Invalid event object.");
+		}
+		final CancelAccountPage cancelAccountPage = new CancelAccountPage(eventInfo, this.oauthUrlSigner);
+		setResponsePage(cancelAccountPage);
+	}
+}

--- a/sample-isv-web/src/main/java/com/appdirect/isv/integration/wicket/pages/procurement/CreateAccountPage.html
+++ b/sample-isv-web/src/main/java/com/appdirect/isv/integration/wicket/pages/procurement/CreateAccountPage.html
@@ -62,6 +62,7 @@
 					<tr>
 						<td colspan="2">
 							<button wicket:id="createAccount">Create</button>
+							<button wicket:id="failure">Failure</button>
 						</td>
 					</tr>
 				</tbody>

--- a/sample-isv-web/src/main/java/com/appdirect/isv/integration/wicket/pages/procurement/CreateAccountSecureRedirectPage.java
+++ b/sample-isv-web/src/main/java/com/appdirect/isv/integration/wicket/pages/procurement/CreateAccountSecureRedirectPage.java
@@ -1,0 +1,27 @@
+package com.appdirect.isv.integration.wicket.pages.procurement;
+
+import org.apache.wicket.request.mapper.parameter.PageParameters;
+import org.wicketstuff.annotation.mount.MountPath;
+
+import com.appdirect.isv.integration.remote.type.EventType;
+import com.appdirect.isv.integration.remote.vo.EventInfo;
+
+/**
+ * This page is secured and acts as an authorization intermediary for the interactive create subscription flow.
+ * The user must first go through this secured page to be authenticated and then will be redirected to the unsecured
+ * CreateAccountPage to finish the creation flow.
+ */
+@MountPath("/appdirect/create")
+public class CreateAccountSecureRedirectPage extends BaseIntegrationPage {
+
+	public CreateAccountSecureRedirectPage(final PageParameters parameters) {
+		super(parameters);
+
+		EventInfo eventInfo = readEvent(parameters);
+		if (eventInfo == null || eventInfo.getType() != EventType.SUBSCRIPTION_ORDER) {
+			throw new IllegalStateException("Invalid event object.");
+		}
+		final CreateAccountPage createAccountPage = new CreateAccountPage(eventInfo, this.basePath, this.applicationProfile, this.oauthUrlSigner);
+		setResponsePage(createAccountPage);
+	}
+}

--- a/sample-isv-web/src/main/java/com/appdirect/isv/integration/wicket/pages/procurement/UpgradeAccountPage.html
+++ b/sample-isv-web/src/main/java/com/appdirect/isv/integration/wicket/pages/procurement/UpgradeAccountPage.html
@@ -35,6 +35,7 @@
 			</div>
 			<div>
 				<button wicket:id="upgradeAccount">Upgrade</button>
+				<button wicket:id="failure">Failure</button>
 			</div>
 		</div>
 	</wicket:extend>

--- a/sample-isv-web/src/main/java/com/appdirect/isv/integration/wicket/pages/procurement/UpgradeAccountSecureRedirectPage.java
+++ b/sample-isv-web/src/main/java/com/appdirect/isv/integration/wicket/pages/procurement/UpgradeAccountSecureRedirectPage.java
@@ -1,0 +1,26 @@
+package com.appdirect.isv.integration.wicket.pages.procurement;
+
+import org.apache.wicket.request.mapper.parameter.PageParameters;
+import org.wicketstuff.annotation.mount.MountPath;
+
+import com.appdirect.isv.integration.remote.type.EventType;
+import com.appdirect.isv.integration.remote.vo.EventInfo;
+
+/**
+ * This page is secured and acts as an authorization intermediary for the interactive upgrade subscription flow.
+ * The user must first go through this secured page to be authenticated and then will be redirected to the unsecured
+ * UpgradeAccountPage to finish the upgrade flow.
+ */
+@MountPath("/appdirect/upgrade")
+public class UpgradeAccountSecureRedirectPage extends BaseIntegrationPage {
+	public UpgradeAccountSecureRedirectPage(PageParameters parameters) {
+		super(parameters);
+
+		EventInfo eventInfo = readEvent(parameters);
+		if (eventInfo == null || eventInfo.getType() != EventType.SUBSCRIPTION_CHANGE) {
+			throw new IllegalStateException("Invalid event object.");
+		}
+		final UpgradeAccountPage upgradeAccountPage = new UpgradeAccountPage(eventInfo, this.applicationProfile, this.oauthUrlSigner);
+		setResponsePage(upgradeAccountPage);
+	}
+}


### PR DESCRIPTION
#### [JiraTicket](https://appdirect.jira.com/browse/DS-14011)
 
#### Description
1. Action : The Sample ISV will go through a secured page that redirects the user toward the page where he/she can create/upgrade/cancel the subscription. The last page is unsecured so that the authentication flow is used only in the preceding secured redirection page. Also, the Hibernate Interceptor is used to populate 'created_on' and 'last_modified_date' fields automatically for each Sample ISV entity.
2. Scope : Sample ISV app
3. Why : Using the Sample ISV to simulate and Interactive endpoint, we are able to go from the AppDirect Marketplace checkout and redirect to the Sample ISV. Though, when you click on the "Create" button from there, the Sample ISV crashes with 401 : Invalid signature for signature method HMAC-SHA1.
 
#### Manual merge checklist:
- [ ]  Code Review completed.
- [ ]  Code coverage 