### PR TITLE
Adjust the memory settings of the Sample ISV

### DIFF
--- a/sample-isv-web/pom.xml
+++ b/sample-isv-web/pom.xml
@@ -233,7 +233,7 @@
 					<skipDocker>false</skipDocker>
 					<baseImage>openjdk:8u121-jdk</baseImage>
 					<imageName>docker.appdirectondemand.com/sample-isv/sample-isv</imageName>
-					<entryPoint>["java", "-server", "-Djava.security.egd=file:/dev/urandom", "-Xms256m", "-Xmx256m", "-XX:MaxMetaspaceSize=96m", "-jar", "/${project.build.finalName}.jar"]</entryPoint>
+					<entryPoint>["java", "-server", "-Djava.security.egd=file:/dev/urandom", "-Xms160m", "-Xmx160m", "-XX:MaxMetaspaceSize=96m", "-Xss512k", "-jar", "/${project.build.finalName}.jar"]</entryPoint>
 					<imageTags>
 						<imageTag>${project.version}</imageTag>
 					</imageTags>


### PR DESCRIPTION
Current memory settings for the Sample ISV docker image are a bit too high for a 512MB container. 