### PR TITLE
DS-15180 - Fix OpenID Intermittent SSO failure

### DIFF
--- a/sample-isv-web/pom.xml
+++ b/sample-isv-web/pom.xml
@@ -157,6 +157,13 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-redis</artifactId>
 		</dependency>
+
+		<!-- Flyway -->
+		<dependency>
+			<groupId>org.flywaydb</groupId>
+			<artifactId>flyway-core</artifactId>
+		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/sample-isv-web/pom.xml
+++ b/sample-isv-web/pom.xml
@@ -233,7 +233,7 @@
 					<skipDocker>false</skipDocker>
 					<baseImage>openjdk:8u121-jdk</baseImage>
 					<imageName>docker.appdirectondemand.com/sample-isv/sample-isv</imageName>
-					<entryPoint>["java", "-server", "-Djava.security.egd=file:/dev/urandom", "-Xms256m", "-Xmx256m", "-XX:MaxMetaspaceSize=96m", "-jar", "/${project.build.finalName}.jar"]</entryPoint>
+					<entryPoint>["java", "-server", "-Djava.security.egd=file:/dev/urandom", "-Xms160m", "-Xmx160m", "-XX:MaxMetaspaceSize=96m", "-Xss512k", "-jar", "/${project.build.finalName}.jar"]</entryPoint>
 					<imageTags>
 						<imageTag>${project.version}</imageTag>
 					</imageTags>

--- a/sample-isv-web/src/main/resources/application.yml
+++ b/sample-isv-web/src/main/resources/application.yml
@@ -28,3 +28,10 @@ info:
   name: @project.name@
   description: @project.description@
   version: @project.version@
+
+###############################
+# FLYWAY CONFIGURATION
+###############################
+flyway:
+  enabled: true
+  baseline-on-migrate: true

--- a/sample-isv-web/src/main/resources/db/migration/V1.001__Add_OpenID_Associations.sql
+++ b/sample-isv-web/src/main/resources/db/migration/V1.001__Add_OpenID_Associations.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS openid_associations (
+  handle             VARCHAR(255) NOT NULL,
+  opurl              VARCHAR(255) NOT NULL,
+  type               VARCHAR(255) NOT NULL,
+  mackey             VARCHAR(255) NOT NULL,
+  expdate            TIMESTAMP NOT NULL,
+  PRIMARY KEY (handle, opurl)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;


### PR DESCRIPTION
With migration of the internally hosted Sample ISV on the Kubernetes infrastructure, there is now 2 servers that are handling requests, but there is no sticky connection. This is causing intermittent issues as the default ConsumerAssociationStore for OpenID is InMemory. This was changed to be JDBC so that every server can retrieve the generated OpenID Associations.