### PR TITLE
Improve Dockerfile Startup

### DIFF
--- a/sample-isv-web/pom.xml
+++ b/sample-isv-web/pom.xml
@@ -234,19 +234,8 @@
 				<artifactId>docker-maven-plugin</artifactId>
 				<version>0.4.13</version>
 				<configuration>
-					<env>
-						<JAVA_OPTS>""</JAVA_OPTS>
-					</env>
 					<skipDocker>false</skipDocker>
-					<baseImage>openjdk:8u121-jdk</baseImage>
-					<imageName>docker.appdirectondemand.com/sample-isv/sample-isv</imageName>
-					<entryPoint>["java", "-server", "-Djava.security.egd=file:/dev/urandom", "-Xms160m", "-Xmx160m", "-XX:MaxMetaspaceSize=96m", "-Xss512k", "$JAVA_OPTS", "-jar", "/${project.build.finalName}.jar"]</entryPoint>
-					<imageTags>
-						<imageTag>${project.version}</imageTag>
-					</imageTags>
-					<serverId>docker</serverId>
-					<dockerHost>unix:///var/run/docker.sock</dockerHost>
-					<registryUrl>https://docker.appdirectondemand.com/v2/</registryUrl>
+					<dockerDirectory>${project.basedir}/src/main/docker</dockerDirectory>
 					<resources>
 						<resource>
 							<targetPath>/</targetPath>
@@ -254,6 +243,12 @@
 							<include>${project.build.finalName}.jar</include>
 						</resource>
 					</resources>
+					<imageName>docker.appdirect.tools/sample-isv/sample-isv</imageName>
+					<imageTags>
+						<imageTag>${project.version}</imageTag>
+					</imageTags>
+					<serverId>docker</serverId>
+					<registryUrl>https://docker.appdirect.tools/v2/</registryUrl>
 				</configuration>
 			</plugin>
 		</plugins>
@@ -270,8 +265,8 @@
 							<groupId>com.spotify</groupId>
 							<artifactId>docker-maven-plugin</artifactId>
 							<configuration>
-								<imageName>docker.appdirectondemand.com/sample-isv/sample-isv</imageName>
-								<registryUrl>https://docker.appdirectondemand.com/v2</registryUrl>
+								<imageName>docker.appdirect.tools/sample-isv/sample-isv</imageName>
+								<registryUrl>https://docker.appdirect.tools/v2</registryUrl>
 								<serverId>docker</serverId>
 								<pushImage>true</pushImage>
 							</configuration>

--- a/sample-isv-web/src/main/docker/Dockerfile
+++ b/sample-isv-web/src/main/docker/Dockerfile
@@ -1,0 +1,11 @@
+FROM openjdk:8-jre-alpine
+
+ADD sample-isv-web.jar sample-isv-web.jar
+
+ENV XMS "-Xms160m"
+ENV XMX "-Xmx160m"
+ENV METASPACE "-XX:MaxMetaspaceSize=96m"
+ENV XSS "-Xss512k"
+ENV JAVA_OPTS=""
+
+ENTRYPOINT [ "sh", "-c", "exec java -server -Djava.security.egd=file:/dev/urandom $XMS $XMX $METASPACE $XSS $JAVA_OPTS -jar /sample-isv-web.jar" ]


### PR DESCRIPTION
- Changed the way to generate the Docker image from using the `docker-maven-plugin` entryPoint to using a `Dockerfile`
- Changed the JDK version to use `openjdk:8-jre-alpine` as it's more light-weight and appropriate for a micro-service