### PR TITLE
Disable the automatic Foreign Key generation from Hibernate

### DIFF
--- a/sample-isv-model/src/main/java/com/appdirect/isv/model/Account.java
+++ b/sample-isv-model/src/main/java/com/appdirect/isv/model/Account.java
@@ -4,7 +4,9 @@ import java.util.List;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
+import javax.persistence.ConstraintMode;
 import javax.persistence.Entity;
+import javax.persistence.ForeignKey;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -49,13 +51,15 @@ public class Account extends TimestampedObject {
 	private String samlIdpMetadataUrl;
 
 	@ManyToOne
-	@JoinColumn(name = "application_profile_id")
+	@JoinColumn(name = "application_profile_id", foreignKey = @ForeignKey(value = ConstraintMode.NO_CONSTRAINT))
 	private ApplicationProfile applicationProfile;
 
 	@OneToMany(mappedBy = "account", orphanRemoval = true, cascade = { CascadeType.ALL })
+	@org.hibernate.annotations.ForeignKey(name = "none")
 	private List<User> users = Lists.newArrayList();
 
 	@OneToMany(mappedBy = "account", orphanRemoval = true, cascade = { CascadeType.ALL })
+	@org.hibernate.annotations.ForeignKey(name = "none")
 	private List<Addon> addons = Lists.newArrayList();
 
 	public Account(ApplicationProfile applicationProfile) {

--- a/sample-isv-model/src/main/java/com/appdirect/isv/model/Addon.java
+++ b/sample-isv-model/src/main/java/com/appdirect/isv/model/Addon.java
@@ -1,7 +1,9 @@
 package com.appdirect.isv.model;
 
 import javax.persistence.Column;
+import javax.persistence.ConstraintMode;
 import javax.persistence.Entity;
+import javax.persistence.ForeignKey;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -32,6 +34,6 @@ public class Addon extends TimestampedObject {
 	private Integer quantity;
 
 	@ManyToOne
-	@JoinColumn(name = "account_id")
+	@JoinColumn(name = "account_id", foreignKey = @ForeignKey(value = ConstraintMode.NO_CONSTRAINT))
 	private Account account;
 }

--- a/sample-isv-model/src/main/java/com/appdirect/isv/model/User.java
+++ b/sample-isv-model/src/main/java/com/appdirect/isv/model/User.java
@@ -1,7 +1,9 @@
 package com.appdirect.isv.model;
 
 import javax.persistence.Column;
+import javax.persistence.ConstraintMode;
 import javax.persistence.Entity;
+import javax.persistence.ForeignKey;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -53,6 +55,6 @@ public class User extends TimestampedObject {
 	private boolean admin = false;
 
 	@ManyToOne
-	@JoinColumn(name = "account_id")
+	@JoinColumn(name = "account_id", foreignKey = @ForeignKey(value = ConstraintMode.NO_CONSTRAINT))
 	private Account account;
 }


### PR DESCRIPTION
Quickest fix to avoid generation of Foreign Keys automatically without updating to latest Hibernate version or completely disabling DDL generation.

The current solution is based off solutions provided on StackOverflow:
 - https://stackoverflow.com/a/46166729
 - https://stackoverflow.com/q/27040735